### PR TITLE
[snmpagent] [201911] Fix hardcoded qsfp lane count by reading sensor status from DB

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -25,24 +25,6 @@ SNMP_OVERLAY_DB = 'SNMP_OVERLAY_DB'
 TABLE_NAME_SEPARATOR_COLON = ':'
 TABLE_NAME_SEPARATOR_VBAR = '|'
 
-# This is used in both rfc2737 and rfc3433
-SENSOR_PART_ID_MAP = {
-    "temperature":  1,
-    "voltage":      2,
-    "rx1power":     11,
-    "rx2power":     21,
-    "rx3power":     31,
-    "rx4power":     41,
-    "tx1bias":      12,
-    "tx2bias":      22,
-    "tx3bias":      32,
-    "tx4bias":      42,
-    "tx1power":     13,
-    "tx2power":     23,
-    "tx3power":     33,
-    "tx4power":     43,
-}
-
 # IfIndex to OID multiplier for transceiver
 IFINDEX_SUB_ID_MULTIPLIER = 1000
 
@@ -399,7 +381,7 @@ def get_transceiver_sub_id(ifindex):
 
     return (ifindex * IFINDEX_SUB_ID_MULTIPLIER, )
 
-def get_transceiver_sensor_sub_id(ifindex, sensor):
+def get_transceiver_sensor_sub_id(ifindex, offset):
     """
     Returns sub OID for transceiver sensor. Sub OID is calculated as folows:
     +-------------------------------------+------------------------------+
@@ -417,7 +399,7 @@ def get_transceiver_sensor_sub_id(ifindex, sensor):
     """
 
     transceiver_oid, = get_transceiver_sub_id(ifindex)
-    return (transceiver_oid + SENSOR_PART_ID_MAP[sensor], )
+    return (transceiver_oid + offset, )
 
 def get_redis_pubsub(db_conn, db_name, pattern):
     redis_client = db_conn.get_redis_client(db_name)

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -10,6 +10,13 @@ from ax_interface import MIBMeta, MIBUpdater, ValueType, SubtreeMIBEntry
 from sonic_ax_impl import mibs
 from sonic_ax_impl.mibs import Namespace
 
+from .transceiver_sensor_data import TransceiverSensorData
+from .transceiver_sensor_data import TransceiverTempSensorData
+from .transceiver_sensor_data import TransceiverVoltageSensorData
+from .transceiver_sensor_data import TransceiverRxPowerSensorData
+from .transceiver_sensor_data import TransceiverTxPowerSensorData
+from .transceiver_sensor_data import TransceiverTxBiasSensorData
+
 @unique
 class EntitySensorDataType(int, Enum):
     """
@@ -206,34 +213,13 @@ class XcvrTxPowerSensor(SensorInterface):
     CONVERTER = Converters.CONV_dBm_mW
 
 
-# mapping between DB key and Sensor object
-TRANSCEIVER_SENSOR_MAP = {
-    "temperature": XcvrTempSensor,
-    "voltage":     XcvrVoltageSensor,
-    "rx1power":    XcvrRxPowerSensor,
-    "rx2power":    XcvrRxPowerSensor,
-    "rx3power":    XcvrRxPowerSensor,
-    "rx4power":    XcvrRxPowerSensor,
-    "tx1bias":     XcvrTxBiasSensor,
-    "tx2bias":     XcvrTxBiasSensor,
-    "tx3bias":     XcvrTxBiasSensor,
-    "tx4bias":     XcvrTxBiasSensor,
-    "tx1power":    XcvrTxPowerSensor,
-    "tx2power":    XcvrTxPowerSensor,
-    "tx3power":    XcvrTxPowerSensor,
-    "tx4power":    XcvrTxPowerSensor,
-}
-
-
-def get_transceiver_sensor(sensor_key):
-    """
-    Gets transceiver sensor object
-    :param sensor_key: Sensor key from XcvrDomDB
-    :param ifindex: Interface index associated with transceiver
-    :return: Sensor object.
-    """
-
-    return TRANSCEIVER_SENSOR_MAP[sensor_key]
+TransceiverSensorData.bind_sensor_interface({
+    TransceiverTempSensorData:    XcvrTempSensor,
+    TransceiverVoltageSensorData: XcvrVoltageSensor,
+    TransceiverRxPowerSensorData: XcvrRxPowerSensor,
+    TransceiverTxPowerSensorData: XcvrTxPowerSensor,
+    TransceiverTxBiasSensorData:  XcvrTxBiasSensor
+})
 
 
 class PhysicalSensorTableMIBUpdater(MIBUpdater):
@@ -311,14 +297,11 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
             if not transceiver_dom_entry_data:
                 continue
 
-            for sensor_key in map(bytes.decode, transceiver_dom_entry_data):
-                if sensor_key not in TRANSCEIVER_SENSOR_MAP:
-                    continue
-
-                raw_sensor_value = transceiver_dom_entry_data.get(sensor_key.encode()).decode()
-
-                sensor = get_transceiver_sensor(sensor_key)
-                sub_id = mibs.get_transceiver_sensor_sub_id(ifindex, sensor_key)
+            sensor_data_list = TransceiverSensorData.create_sensor_data(transceiver_dom_entry_data)
+            for sensor_data in sensor_data_list:
+                raw_sensor_value = sensor_data.get_raw_value()
+                sensor = sensor_data.sensor_interface
+                sub_id = mibs.get_transceiver_sensor_sub_id(ifindex, sensor_data.get_oid_offset())
 
                 try:
                     mib_values = sensor.mib_values(raw_sensor_value)

--- a/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
+++ b/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
@@ -43,6 +43,7 @@ class TransceiverSensorData:
                 if match_result:
                     sensor_data = concrete_type(name, value, match_result)
                     sensor_data_list.append(sensor_data)
+                    break
         return sensor_data_list
 
     @classmethod

--- a/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
+++ b/src/sonic_ax_impl/mibs/ietf/transceiver_sensor_data.py
@@ -1,0 +1,216 @@
+import re
+
+
+def transceiver_sensor_data():
+    """
+    Decorator for auto registering transceiver sensor data type
+    """
+    def wrapper(object_type):
+        TransceiverSensorData.register(object_type)
+        return object_type
+
+    return wrapper
+
+
+class TransceiverSensorData:
+    """
+    Base transceiver sensor data class. Responsible for:
+        1. Manage concrete sensor data class
+        2. Create concrete sensor data instances
+        3. Provide common logic for concrete sensor data class
+    """
+    concrete_type_list = []
+    sensor_interface = None
+
+    def __init__(self, key, value, match_result):
+        self._key = key
+        self._value = value
+        self._match_result = match_result
+
+    @classmethod
+    def create_sensor_data(cls, sensor_data_dict):
+        """
+        Create sensor data instances according to the sensor data got from redis
+        :param sensor_data_dict: sensor data got from redis
+        :return: A sorted sensor data instance list
+        """
+        sensor_data_list = []
+        for name, value in sensor_data_dict.items():
+            name = bytes.decode(name)
+            value = bytes.decode(value)
+            for concrete_type in cls.concrete_type_list:
+                match_result = re.match(concrete_type.get_pattern(), name)
+                if match_result:
+                    sensor_data = concrete_type(name, value, match_result)
+                    sensor_data_list.append(sensor_data)
+        return sensor_data_list
+
+    @classmethod
+    def sort_sensor_data(cls, sensor_data_list):
+        return sorted(sensor_data_list, key=lambda x: x.get_sort_factor())
+
+    @classmethod
+    def register(cls, concrete_type):
+        """
+        Register concrete sensor data type
+        :param concrete_type: concrete sensor data class
+        :return:
+        """
+        cls.concrete_type_list.append(concrete_type)
+
+    @classmethod
+    def bind_sensor_interface(cls, sensor_interface_dict):
+        for concrete_type in cls.concrete_type_list:
+            if concrete_type in sensor_interface_dict:
+                concrete_type.sensor_interface = sensor_interface_dict[concrete_type]
+
+    def get_key(self):
+        """
+        Get the redis key of this sensor
+        """
+        return self._key
+
+    def get_raw_value(self):
+        """
+        Get raw redis value of this sensor
+        """
+        return self._value
+
+    def get_name(self):
+        """
+        Get the name of this sensor. Concrete sensor data class must override
+        this.
+        """
+        raise NotImplementedError
+
+    def get_sort_factor(self):
+        """
+        Get sort factor for this sensor. Concrete sensor data class must override
+        this.
+        """
+        raise NotImplementedError
+
+    def get_lane_number(self):
+        """
+        Get lane number of this sensor. For example, some transceivers have more than one rx power sensor, the sub index
+        of rx1power is 1, the sub index of rx2power is 2.
+        """
+        return int(self._match_result.group(1))
+
+    def get_oid_offset(self):
+        """
+        Get OID offset of this sensor.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_pattern(cls):
+        """
+        Return regular expression pattern for matching the sensor name. Concrete sensor data class must override
+        this.
+        """
+        raise NotImplementedError
+
+
+@transceiver_sensor_data()
+class TransceiverTempSensorData(TransceiverSensorData):
+    SORT_FACTOR = 0
+    OID_OFFSET = 1
+
+    @classmethod
+    def get_pattern(cls):
+        return 'temperature'
+
+    def get_name(self):
+        return 'Temperature'
+
+    def get_sort_factor(self):
+        return TransceiverTempSensorData.SORT_FACTOR
+
+    def get_lane_number(self):
+        return 0
+
+    def get_oid_offset(self):
+        return TransceiverTempSensorData.OID_OFFSET
+
+
+@transceiver_sensor_data()
+class TransceiverVoltageSensorData(TransceiverSensorData):
+    SORT_FACTOR = 9000
+    OID_OFFSET = 2
+
+    @classmethod
+    def get_pattern(cls):
+        return 'voltage'
+
+    def get_name(self):
+        return 'Voltage'
+
+    def get_sort_factor(self):
+        return TransceiverVoltageSensorData.SORT_FACTOR
+
+    def get_lane_number(self):
+        return 0
+
+    def get_oid_offset(self):
+        return TransceiverVoltageSensorData.OID_OFFSET
+
+
+@transceiver_sensor_data()
+class TransceiverRxPowerSensorData(TransceiverSensorData):
+    SORT_FACTOR = 2000
+    OID_OFFSET = 1
+    OID_MULTIPLE = 10
+
+    @classmethod
+    def get_pattern(cls):
+        return 'rx(\d+)power'
+
+    def get_name(self):
+        return 'RX Power'
+
+    def get_sort_factor(self):
+        return TransceiverRxPowerSensorData.SORT_FACTOR + self.get_lane_number()
+
+    def get_oid_offset(self):
+        return TransceiverRxPowerSensorData.OID_OFFSET + self.get_lane_number() * TransceiverRxPowerSensorData.OID_MULTIPLE
+
+
+@transceiver_sensor_data()
+class TransceiverTxPowerSensorData(TransceiverSensorData):
+    SORT_FACTOR = 1000
+    OID_OFFSET = 3
+    OID_MULTIPLE = 10
+
+    @classmethod
+    def get_pattern(cls):
+        return 'tx(\d+)power'
+
+    def get_name(self):
+        return 'TX Power'
+
+    def get_sort_factor(self):
+        return TransceiverTxPowerSensorData.SORT_FACTOR + self.get_lane_number()
+
+    def get_oid_offset(self):
+        return TransceiverTxPowerSensorData.OID_OFFSET + self.get_lane_number() * TransceiverTxPowerSensorData.OID_MULTIPLE
+
+
+@transceiver_sensor_data()
+class TransceiverTxBiasSensorData(TransceiverSensorData):
+    SORT_FACTOR = 3000
+    OID_OFFSET = 2
+    OID_MULTIPLE = 10
+
+    @classmethod
+    def get_pattern(cls):
+        return 'tx(\d+)bias'
+
+    def get_name(self):
+        return 'TX Bias'
+
+    def get_sort_factor(self):
+        return TransceiverTxBiasSensorData.SORT_FACTOR + self.get_lane_number()
+
+    def get_oid_offset(self):
+        return TransceiverTxBiasSensorData.OID_OFFSET + self.get_lane_number() * TransceiverTxBiasSensorData.OID_MULTIPLE


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The current snmpagent implementation hardcoded qsfp lanes to 4, but qsfp-dd has 8 lanes. In that case snmp query only display the sensors of first 4 lanes. This PR is to fix it. 

**- How I did it**

1. read actual sensor status from redis db, now we only care temperature, voltage, txpower, rxpower, txbias.
2. sort sensor data to make sure it has a solid order
3. store the data to snmpagent data structure

**- How to verify it**

Manual test on 201911 and run existing regression

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

