### PR TITLE
[rfc2737] Fix issue: expect redis pubsub data to be str type instead of bytes type

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -675,7 +675,7 @@ class PhysicalEntityCacheUpdater(object):
 
             db_entry = msg["channel"].split(":")[-1]
             data = msg['data']  # event data
-            if not isinstance(data, bytes):
+            if not isinstance(data, str):
                 continue
 
             # extract interface name


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Change redis pubsub expect data type from bytes to str. There was a snmpagent framework change which transfer redis pubsub data from bytes to str, after that change, there is no need for non-framework code to do this transfer. So now we need handle str data directly.

**- How I did it**

Change data expectation from bytes to str

**- How to verify it**

Run regression and manual test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

